### PR TITLE
[bug fix] Uses libpatch version 2

### DIFF
--- a/lib/charms/acme_client_operator/v0/acme_client.py
+++ b/lib/charms/acme_client_operator/v0/acme_client.py
@@ -69,7 +69,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 2
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Description

Uses libpatch version 2. Reason is that a previous PR bumped to v.2 but the changes weren't published to charmhub. Now the last PR bumped to v3 and the published lib was v1 which prevented the publishing action.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I Have bumped the version of the library
