### PR TITLE
Call children for valid configurations on_certificate_request

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -38,7 +38,7 @@ class MockExec:
 
 class AcmeTestCharm(AcmeClient):
     def __init__(self, *args):
-        """Uses the Orc8rBase library to manage events."""
+        """Uses the AcmeClient library to manage events."""
         super().__init__(*args, plugin="namecheap")
         self.valid_config = True
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -14,7 +14,7 @@ from charms.tls_certificates_interface.v1.tls_certificates import (  # type: ign
     generate_private_key,
 )
 from ops import testing
-from ops.model import BlockedStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import ExecError
 from ops.testing import Harness
 
@@ -40,6 +40,19 @@ class AcmeTestCharm(AcmeClient):
     def __init__(self, *args):
         """Uses the Orc8rBase library to manage events."""
         super().__init__(*args, plugin="namecheap")
+        self.valid_config = True
+
+    def _on_config_changed(self, _):
+        if not self.valid_config:
+            self.unit.status = BlockedStatus("Invalid specific configuration")
+            return
+        if not self.validate_generic_acme_config():
+            return
+        self.unit.status = ActiveStatus()
+
+    @property
+    def _plugin_config(self):
+        return {}
 
 
 class TestCharm(unittest.TestCase):
@@ -265,4 +278,23 @@ class TestCharm(unittest.TestCase):
 
         self.add_csr_to_remote_unit_relation_data(relation_id=relation_id, app_or_unit="remote/0")
 
-        assert self.harness.charm.unit.status == BlockedStatus("Invalid ACME configuration")
+        assert self.harness.charm.unit.status == BlockedStatus("Invalid email address")
+
+    def test_given_invalid_specific_config_when_certificate_creation_request_then_status_is_blocked(  # noqa: E501
+        self,
+    ):
+        self.harness.update_config(
+            {
+                "email": "banana@email.com",
+                "server": "https://acme-v02.api.letsencrypt.org/directory",
+            }
+        )
+        self.harness.set_leader(True)
+        relation_id = self.harness.add_relation("certificates", "remote")
+        self.harness.add_relation_unit(relation_id, "remote/0")
+        self.harness.set_can_connect("lego", True)
+        self.harness.charm.valid_config = False
+
+        self.add_csr_to_remote_unit_relation_data(relation_id=relation_id, app_or_unit="remote/0")
+
+        self.harness.charm.unit.status == BlockedStatus("Invalid specific configuration")


### PR DESCRIPTION
# Description

Calls `_on_config_changed` when receiving a certificate request to let the children validate its specific configuration.

Will fix https://github.com/canonical/route53-acme-operator/issues/13 when it is merged and the lib updated in all children charms.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I Have bumped the version of the library
