### PR TITLE
docs: Adds Charmhub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-# acme-client-operator
-
-## Description
+# ACME Client Operator (K8s)
+[![CharmHub Badge](https://charmhub.io/acme-client-operator/badge.svg)](https://charmhub.io/acme-client-operator)
 
 ACME Client Operator is a placeholder charm that contains the `acme_client` library.
 The library contains a base charm implements the provider side of the `tls-certificates-interface`
-to provide signed certificates from an ACME servers, using LEGO
-(https://go-acme.github.io/lego).
+to provide signed certificates from an ACME servers, using [LEGO](https://go-acme.github.io/lego).
 It should be used as a base for charms that need to provide TLS certificates.
 
 ## Usage


### PR DESCRIPTION
# Description

The Telco charms currently have broken statuses in the [charm engineering page](https://releases.juju.is/?team=Telco). This PR adds the appropriate charmhub badge to address this.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I Have bumped the version of the library
